### PR TITLE
Adding the url rule for the listing of a list type

### DIFF
--- a/src/Wishlist.php
+++ b/src/Wishlist.php
@@ -112,6 +112,7 @@ class Wishlist extends Plugin
         Event::on(UrlManager::class, UrlManager::EVENT_REGISTER_CP_URL_RULES, function(RegisterUrlRulesEvent $event) {
             $event->rules = array_merge($event->rules, [
                 'wishlist' => 'wishlist/lists/index',
+                'wishlist/lists/<listTypeHandle:{handle}>' => 'wishlist/lists/index',
                 'wishlist/lists/<listTypeHandle:{handle}>/new' => 'wishlist/lists/edit-list',
                 'wishlist/lists/<listTypeHandle:{handle}>/<listId:\d+>' => 'wishlist/lists/edit-list',
                 'wishlist/lists/<listTypeHandle:{handle}>/<listId:\d+>/items/<itemId:\d+>' => 'wishlist/items/edit-item',


### PR DESCRIPTION
If that is not present, going directly to /admin/wishlist/lists/wishlist (or any other list type) doesn't work.