### PR TITLE
Fix New List Creation

### DIFF
--- a/src/templates/lists/_edit.html
+++ b/src/templates/lists/_edit.html
@@ -87,7 +87,7 @@
     <div id="items" class="">
         <h2>{{ 'List Items' | t('comments') }}</h2>
 
-        {% if list.items.count() %}
+        {% if list.id and list.items.count() %}
             {% set elementAttr = {
                 elementType: className(list),
                 disabledElementIds: null,


### PR DESCRIPTION
Fix for #10, which seemed to be an issue with attempting to fetch List Items prior to the list having an ID.

The List element's `getItems()` method would (rightly) return `null` if there was no ID, so I opted for a template-level guard against this, rather than returning an empty array (which is no better than `null`, granted none of the `ElementQuery` chained methods would work there, anyway).

Hope this floats yer boat!