### PR TITLE
List type parameters for Item actions

### DIFF
--- a/src/Wishlist.php
+++ b/src/Wishlist.php
@@ -112,6 +112,7 @@ class Wishlist extends Plugin
         Event::on(UrlManager::class, UrlManager::EVENT_REGISTER_CP_URL_RULES, function(RegisterUrlRulesEvent $event) {
             $event->rules = array_merge($event->rules, [
                 'wishlist' => 'wishlist/lists/index',
+                'wishlist/lists/<listTypeHandle:{handle}>' => 'wishlist/lists/index',
                 'wishlist/lists/<listTypeHandle:{handle}>/new' => 'wishlist/lists/edit-list',
                 'wishlist/lists/<listTypeHandle:{handle}>/<listId:\d+>' => 'wishlist/lists/edit-list',
                 'wishlist/lists/<listTypeHandle:{handle}>/<listId:\d+>/items/<itemId:\d+>' => 'wishlist/items/edit-item',

--- a/src/controllers/ItemsController.php
+++ b/src/controllers/ItemsController.php
@@ -137,7 +137,18 @@ class ItemsController extends BaseController
         $elementId = $request->getParam('elementId');
         $listId = $request->getParam('listId');
 
-        $list = Wishlist::$plugin->getLists()->getList($listId, true);
+        $listTypeId = $request->getParam('listTypeId');
+        $listTypeHandle = $request->getParam('listTypeHandle');
+
+        if(!$listTypeId && $listTypeHandle){
+            // Always take the ID first. If both are sent, Handle is ignored.
+            $listType = WishList::$plugin->getListTypes()->getListTypeByHandle($listTypeHandle);
+            if($listType) {
+                $listTypeId = $listType->id;
+            }
+        }
+        
+        $list = Wishlist::$plugin->getLists()->getList($listId, true, $listTypeId);
 
         if (!$elementId) {
             return $this->returnError('Element ID must be provided.');
@@ -165,7 +176,19 @@ class ItemsController extends BaseController
         $elementId = $request->getParam('elementId');
         $listId = $request->getParam('listId');
 
-        $list = Wishlist::$plugin->getLists()->getList($listId, true);
+        $listTypeId = $request->getParam('listTypeId');
+        $listTypeHandle = $request->getParam('listTypeHandle');
+
+        if(!$listTypeId && $listTypeHandle){
+            // Always take the ID first. If both are sent, Handle is ignored.
+            $listType = WishList::$plugin->getListTypes()->getListTypeByHandle($listTypeHandle);
+            if($listType) {
+                $listTypeId = $listType->id;
+            }
+        }
+
+        $list = Wishlist::$plugin->getLists()->getList($listId, true, $listTypeId);
+
 
         if (!$elementId) {
             return $this->returnError('Element ID must be provided.');
@@ -219,7 +242,18 @@ class ItemsController extends BaseController
         $elementId = $request->getParam('elementId');
         $listId = $request->getParam('listId');
 
-        $item = WishList::$plugin->getItems()->createItem($elementId, $listId);
+        $listTypeId = $request->getParam('listTypeId');
+        $listTypeHandle = $request->getParam('listTypeHandle');
+
+        if(!$listTypeId && $listTypeHandle){
+            // Always take the ID first. If both are sent, Handle is ignored.
+            $listType = WishList::$plugin->getListTypes()->getListTypeByHandle($listTypeHandle);
+            if($listType) {
+                $listTypeId = $listType->id;
+            }
+        }
+
+        $item = WishList::$plugin->getItems()->createItem($elementId, $listId, $listTypeId);
 
         return $item;
     }

--- a/src/services/Items.php
+++ b/src/services/Items.php
@@ -44,9 +44,9 @@ class Items extends Component
         return true;
     }
 
-    public function createItem($elementId, $listId)
+    public function createItem($elementId, $listId, $listTypeId)
     {
-        $list = Wishlist::$plugin->getLists()->getList($listId, true);
+        $list = Wishlist::$plugin->getLists()->getList($listId, true, $listTypeId);
         $element = Craft::$app->getElements()->getElementById($elementId);
 
         $item = new Item();


### PR DESCRIPTION
This merge includes everything required to Add, Remove and Toggle Items from specific List Types.

You can send either listTypeId or listTypeHandle through,  ID taking precedence on Handle if both are sent through. 

Also a fix for #6 .