### PR TITLE
Fix issue with options param in remove and toggle endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Fix issue where trying to remove or toggle a wishlist item with the `options` param could have no effect
+
 ## 1.4.8 - 2021-05-08
 
 ### Added

--- a/src/controllers/ItemsController.php
+++ b/src/controllers/ItemsController.php
@@ -284,7 +284,8 @@ class ItemsController extends BaseController
             }
 
             if ($options) {
-                $query->options($options);
+                $optionsSignature = Wishlist::getInstance()->getItems()->getOptionsSignature($options);
+                $query->optionsSignature($optionsSignature);
             }
 
             if ($elementId) {
@@ -381,7 +382,8 @@ class ItemsController extends BaseController
             }
 
             if ($options) {
-                $query->options($options);
+                $optionsSignature = Wishlist::getInstance()->getItems()->getOptionsSignature($options);
+                $query->optionsSignature($optionsSignature);
             }
 
             if ($elementId) {

--- a/src/controllers/ListsController.php
+++ b/src/controllers/ListsController.php
@@ -10,7 +10,6 @@ use Craft;
 use craft\base\Element;
 use craft\elements\User;
 use craft\helpers\DateTimeHelper;
-use craft\helpers\Json;
 use craft\helpers\Localization;
 use craft\helpers\UrlHelper;
 use craft\models\Site;

--- a/src/elements/Item.php
+++ b/src/elements/Item.php
@@ -257,9 +257,7 @@ class Item extends Element
 
     public function getOptionsSignature()
     {
-        ksort($this->_options);
-
-        return md5(Json::encode($this->_options));
+        return Wishlist::getInstance()->getItems()->getOptionsSignature($this->_options);
     }
 
     public function setOptionsSignature($value)

--- a/src/helpers/ProjectConfigData.php
+++ b/src/helpers/ProjectConfigData.php
@@ -3,7 +3,6 @@ namespace verbb\wishlist\helpers;
 
 use Craft;
 use craft\db\Query;
-use craft\helpers\Json;
 
 class ProjectConfigData
 {

--- a/src/services/Items.php
+++ b/src/services/Items.php
@@ -10,6 +10,7 @@ use craft\base\ElementInterface;
 use craft\events\ElementEvent;
 use craft\events\SiteEvent;
 use craft\queue\jobs\ResaveElements;
+use craft\helpers\Json;
 
 use yii\web\UserEvent;
 
@@ -75,5 +76,12 @@ class Items extends Component
         $updateItemSearchIndexes = Wishlist::$plugin->getSettings()->updateItemSearchIndexes;
 
         return Craft::$app->getElements()->saveElement($element, $runValidation, $propagate, $updateItemSearchIndexes);
+    }
+
+    public function getOptionsSignature($options)
+    {
+        ksort($options);
+
+        return md5(Json::encode($options));
     }
 }


### PR DESCRIPTION
Thanks for adding #84 quickly. Unfortunately, I just tested it and discovered an issue, which this PR fixes: looks like setting `options` on the query is not reliable. I'm not exactly sure why because it works in some cases, but I had an item with the options `{"UL Listed":"UL Listed"}` in the DB, and adding `$query->options(['UL Listed' => 'UL Listed'])` couldn't find it, so I was unable to remove it with the `remove` endpoint. Anyway, I changed the implementation to use `optionsSignature` on the query instead, and it works perfectly now. That's what it's for, isn't it?