### PR TITLE
Show list owners with status and thumbnail in list element index view

### DIFF
--- a/src/elements/ListElement.php
+++ b/src/elements/ListElement.php
@@ -15,6 +15,7 @@ use craft\elements\actions\Delete;
 use craft\helpers\ArrayHelper;
 use craft\helpers\DateTimeHelper;
 use craft\helpers\UrlHelper;
+use craft\helpers\Cp;
 use craft\validators\DateTimeValidator;
 
 use yii\base\Exception;
@@ -207,7 +208,10 @@ class ListElement extends Element
             return null;
         }
 
-        return $this->_user = User::find()->id($this->userId)->one();
+        return $this->_user = User::find()
+            ->status(null)
+            ->id($this->userId)
+            ->one();
     }
 
     public function getOwnerId()
@@ -340,11 +344,9 @@ class ListElement extends Element
     {
         switch ($attribute) {
             case 'owner':
-                if ($owner = $this->getOwner()) {
-                    return '<a href="' . $owner->getCpEditUrl() . '">' . $owner . '</a>';
-                }
+                $owner = $this->getOwner();
 
-                return Craft::t('wishlist', 'Guest');
+                return $owner ? Cp::elementHtml($owner) : Craft::t('wishlist', 'Guest');
             case 'type':
                 if ($listType = $this->getType()) {
                     return Craft::t('site', $listType->name);


### PR DESCRIPTION
A small enhancement to the Lists view to show the owner with thumbnail and status for all users. This makes it easier to see which lists belong to suspended users as opposed to guests, where previously both would be shown as 'Guest'. List owners who are not registered users are shown as 'Guest' as before.