### PR TITLE
Fix bug when using custom email templates

### DIFF
--- a/src/controllers/ListsController.php
+++ b/src/controllers/ListsController.php
@@ -7,6 +7,7 @@ use verbb\wishlist\errors\ItemError;
 use verbb\wishlist\errors\ListError;
 use verbb\wishlist\events\AddLineItemEvent;
 use verbb\wishlist\events\AddToCartEvent;
+use verbb\wishlist\helpers\Markdown;
 use verbb\wishlist\models\Settings;
 
 use Craft;
@@ -697,39 +698,55 @@ class ListsController extends BaseController
         $settings = Wishlist::$plugin->getSettings();
 
         $mailer = Craft::$app->getMailer();
-        $message = $mailer->composeFromKey($key, $variables);
-
-        // Default to the current language
         $language = Craft::$app->getRequest()->getIsSiteRequest() ? Craft::$app->language : Craft::$app->getSites()->getPrimarySite()->language;
         $systemMessage = Craft::$app->getSystemMessages()->getMessage($key, $language);
 
         $view = Craft::$app->getView();
 
-        $message->setSubject($view->renderString($systemMessage->subject, $variables, View::TEMPLATE_MODE_SITE));
+        $subject = $view->renderString($systemMessage->subject, $variables, View::TEMPLATE_MODE_SITE);
         $textBody = $view->renderString($systemMessage->body, $variables, View::TEMPLATE_MODE_SITE);
 
+        // Use custom template if configured, otherwise fall back to Craft's default
         if ($settings->templateEmail) {
             $template = $settings->templateEmail;
             $templateMode = View::TEMPLATE_MODE_SITE;
         } else {
-            // Default to the `_special/email` template from Craft.
             $template = '_special/email';
             $templateMode = View::TEMPLATE_MODE_CP;
         }
 
-        try {
-            $message->setHtmlBody($view->renderTemplate($template, array_merge($variables, [
-                'body' => Template::raw(Markdown::process($textBody)),
+        $htmlBody = null;
 
-                // Required when using `_special/email` from Craft.
+        try {
+            $templateVariables = array_merge($variables, [
                 'language' => $language,
-            ]), $templateMode));
-        } catch (Throwable $e) {
-            Wishlist::error('Error rendering email template: {message} {file}:{line}.', [
-                'message' => $e->getMessage(),
-                'file' => $e->getFile(),
-                'line' => $e->getLine(),
             ]);
+
+            // Only add body variable when using Craft's default template
+            if (!$settings->templateEmail) {
+                $templateVariables['body'] = Template::raw(Markdown::process($textBody));
+            }
+
+            $htmlBody = $view->renderTemplate($template, $templateVariables, $templateMode);
+
+            if (empty(trim($htmlBody))) {
+                $htmlBody = null;
+            }
+        } catch (Throwable $e) {
+            Wishlist::error('Error rendering email template: {message}', [
+                'message' => $e->getMessage(),
+            ]);
+        }
+
+        // Use compose() instead of composeFromKey() to ensure custom HTML body is used
+        if ($htmlBody) {
+            $message = $mailer->compose()
+                ->setSubject($subject)
+                ->setTextBody($textBody)
+                ->setHtmlBody($htmlBody);
+        } else {
+            $message = $mailer->composeFromKey($key, $variables);
+            $message->setSubject($subject);
         }
 
         return $message;

--- a/src/helpers/Markdown.php
+++ b/src/helpers/Markdown.php
@@ -1,0 +1,22 @@
+<?php
+namespace verbb\wishlist\helpers;
+
+use yii\helpers\Markdown as YiiMarkdown;
+
+class Markdown extends YiiMarkdown
+{
+    // Static Methods
+    // =========================================================================
+
+    /**
+     * Process markdown text
+     *
+     * @param string $markdown
+     * @param string|null $flavor
+     * @return string
+     */
+    public static function process($markdown, $flavor = null): string
+    {
+        return parent::process($markdown, $flavor);
+    }
+}


### PR DESCRIPTION
Hi Josh

I was opening a ticket few weeks ago (https://github.com/verbb/wishlist/issues/163) under my work github account. I updated the plugin today and got some errors, so I tried to fix them by myself.

Changed the following things:

### Added Missing Markdown Helper

File: src/helpers/Markdown.php (new file)

The plugin was trying to use a Markdown helper class that didn't exist, causing a "Class not found" error when sending emails.

### Updated _renderEmail() Method
File: src/controllers/ListsController.php
Added import for the new Markdown helper
Added support for custom email templates via the templateEmail setting
Fixed email composition to actually use custom HTML templates (was using composeFromKey which ignored custom templates)

